### PR TITLE
[add models]: Add supported_models: qwen2-vl-72b-instruct qwen2.5-vl-3b-instruct qwen2.5-vl-7b-instruct qwen2.5-vl-72b-instruct

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -17,5 +17,9 @@
 | phi3-v                         | phi3-v                                   | [microsoft/Phi-3-vision-128k-instruct](https://huggingface.co/microsoft/Phi-3-vision-128k-instruct)  |
 | qwen2-vl                       | qwen2-vl-2b-instruct                     | [Qwen/Qwen2-VL-2B-Instruct](https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct)                        |
 |                                | qwen2-vl-7b-instruct                     | [Qwen/Qwen2-VL-7B-Instruct](https://huggingface.co/Qwen/Qwen2-VL-7B-Instruct)                        |
+|                                | qwen2-vl-72b-instruct                    | [Qwen/Qwen2-VL-72B-Instruct](https://huggingface.co/Qwen/Qwen2-VL-72B-Instruct)                       |
+|                                | qwen2.5-vl-3b-instruct                   | [Qwen/Qwen2.5-VL-3B-Instruct](https://huggingface.co/Qwen/Qwen2.5-VL-3B-Instruct)    
+|                                | qwen2.5-vl-7b-instruct                   | [Qwen/Qwen2.5-VL-7B-Instruct](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct)    
+|                                | qwen2.5-vl-72b-instruct                  | [Qwen/Qwen2.5-VL-72B-Instruct](https://huggingface.co/Qwen/Qwen2.5-VL-72B-Instruct)                        |
 | llama-3.2-vision               | llama-3.2-11b-vision-instruct            | [meta-llama/Llama-3.2-11B-Vision-Instruct](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct) |
 |                                | llama-3.2-90b-vision-instruct            | [meta-llama/Llama-3.2-90B-Vision-Instruct](https://huggingface.co/meta-llama/Llama-3.2-90B-Vision-Instruct) |

--- a/supported_models.py
+++ b/supported_models.py
@@ -176,6 +176,30 @@ register_model(
     model_hf_path="Qwen/Qwen2-VL-7B-Instruct"
 )
 
+register_model(
+    model_id="qwen2-vl-72b-instruct",
+    model_family_id="qwen2-vl",
+    model_hf_path="Qwen/Qwen2-VL-72B-Instruct"
+)
+
+register_model(
+    model_id="qwen2.5-vl-3b-instruct",
+    model_family_id="qwen2-vl",
+    model_hf_path="Qwen/Qwen2.5-VL-3B-Instruct"
+)
+
+register_model(
+    model_id="qwen2.5-vl-7b-instruct",
+    model_family_id="qwen2-vl",
+    model_hf_path="Qwen/Qwen2.5-VL-7B-Instruct"
+)
+
+register_model(
+    model_id="qwen2.5-vl-72b-instruct",
+    model_family_id="qwen2-vl",
+    model_hf_path="Qwen/Qwen2.5-VL-72B-Instruct"
+)
+
 # llama-3.2-vision -------------------------------------------
 
 register_model(


### PR DESCRIPTION
Qwen2.5-VL released: https://qwenlm.github.io/blog/qwen2.5-vl/

This PR adds support for qwen-2-72b and introduces support for the qwen2.5 series models.