### PR TITLE
[Model Support] Add InternVL2 family (2B/8B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ More and more large multimodal models (LMMs) are being released from time to tim
 
 The codebase is quite flexible. It supports the finetuning of various types of LMMs, including:
 - :city_sunrise: single image models: [LLaVA-1.5](https://huggingface.co/collections/llava-hf/llava-15-65f762d5b6941db5c2ba07e0), [LLaVA-1.6/NeXT](https://huggingface.co/collections/llava-hf/llava-next-65f75c4afac77fd37dbbe6cf), [Phi-3-Vision](https://huggingface.co/microsoft/Phi-3-vision-128k-instruct), [Llama-3.2-Vision](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision)
-- :bookmark_tabs: multiple/interleaved image models: [Qwen-VL-Chat](https://huggingface.co/Qwen/Qwen-VL-Chat), [Qwen2-VL-Instruct](https://huggingface.co/Qwen/Qwen2-VL-7B-Instruct),  [LLaVA-NeXT-Interleave](https://huggingface.co/collections/llava-hf/llava-interleave-668e19a97da0036aad4a2f19), [Qwen2.5-VL-Instruct](https://huggingface.co/Qwen/Qwen2.5-VL-3B-Instruct)
+- :bookmark_tabs: multiple/interleaved image models: [Qwen-VL-Chat](https://huggingface.co/Qwen/Qwen-VL-Chat), [Qwen2-VL-Instruct](https://huggingface.co/Qwen/Qwen2-VL-7B-Instruct),  [LLaVA-NeXT-Interleave](https://huggingface.co/collections/llava-hf/llava-interleave-668e19a97da0036aad4a2f19), [Qwen2.5-VL-Instruct](https://huggingface.co/Qwen/Qwen2.5-VL-3B-Instruct), [InternVL2](https://huggingface.co/OpenGVLab/InternVL2-8B)
 - :movie_camera: video models: [LLaVA-NeXT-Video](https://huggingface.co/collections/llava-hf/llava-next-video-6666a9173a64c7052930f153)
 - :rocket: unified models: [LLaVA-Onevision](https://huggingface.co/collections/llava-hf/llava-onevision-66bb1e9ce8856e210a7ed1fe)
 
@@ -40,6 +40,7 @@ These are great projects/frameworks with large scale and high-degree optimizatio
 
 ## News
 
+- **2025/11/23**: InternVL2 family (2B/8B) is supported now.
 - **2025/01/27**: Qwen2.5 family is supported now.
 - **2024/12/16**: Thanks to the contribution from [lavinal712 (Yuqian)](https://github.com/lavinal712), training with Llama-3.2-Vision is now supported. Also there is a useful script `merge_lora_weights.py` added.
 - **2024/10/16**: We added LLaVA-Onevision. See a caveat when using LLaVA-Onevision [here](https://github.com/zjysteven/lmms-finetune/issues/43). Also we updated the collators to stay in line with the new processing of LLaVA models in transformers.

--- a/collators/__init__.py
+++ b/collators/__init__.py
@@ -19,3 +19,4 @@ from .phi3_v import Phi3VDataCollator
 from .qwen2_vl import Qwen2VLDataCollator
 from .qwen2_5_vl import Qwen2_5_VLDataCollator
 from .llama_3_2_vision import LLaMA3_2_VisionDataCollator
+from .internvl2 import InternVL2DataCollator

--- a/collators/internvl2.py
+++ b/collators/internvl2.py
@@ -17,9 +17,6 @@ from .chat_template_monkey_patch import apply_chat_template
 IMG_START_TOKEN = '<img>'
 IMG_END_TOKEN = '</img>'
 IMG_CONTEXT_TOKEN = '<IMG_CONTEXT>'
-
-
-# https://huggingface.co/OpenGVLab/InternVL2-8B
 IMAGENET_MEAN = (0.485, 0.456, 0.406)
 IMAGENET_STD = (0.229, 0.224, 0.225)
 

--- a/collators/internvl2.py
+++ b/collators/internvl2.py
@@ -1,0 +1,588 @@
+import dataclasses
+import re
+from enum import IntEnum, auto
+from typing import Dict, List, Sequence, Tuple, Union
+
+import numpy as np
+import torch
+import torchvision.transforms as T
+from PIL import Image
+from torchvision.transforms.functional import InterpolationMode
+
+from . import register_collator
+from .base import BaseDataCollator
+from .chat_template_monkey_patch import apply_chat_template
+
+
+IMG_START_TOKEN = '<img>'
+IMG_END_TOKEN = '</img>'
+IMG_CONTEXT_TOKEN = '<IMG_CONTEXT>'
+
+
+# https://huggingface.co/OpenGVLab/InternVL2-8B
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+def build_transform(input_size):
+    MEAN, STD = IMAGENET_MEAN, IMAGENET_STD
+    transform = T.Compose([
+        T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
+        T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
+        T.ToTensor(),
+        T.Normalize(mean=MEAN, std=STD)
+    ])
+    return transform
+
+
+def find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_size):
+    best_ratio_diff = float('inf')
+    best_ratio = (1, 1)
+    area = width * height
+    for ratio in target_ratios:
+        target_aspect_ratio = ratio[0] / ratio[1]
+        ratio_diff = abs(aspect_ratio - target_aspect_ratio)
+        if ratio_diff < best_ratio_diff:
+            best_ratio_diff = ratio_diff
+            best_ratio = ratio
+        elif ratio_diff == best_ratio_diff:
+            if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
+                best_ratio = ratio
+    return best_ratio
+
+
+def dynamic_preprocess(image, min_num=1, max_num=12, image_size=448, use_thumbnail=False):
+    orig_width, orig_height = image.size
+    aspect_ratio = orig_width / orig_height
+
+    # calculate the existing image aspect ratio
+    target_ratios = set(
+        (i, j) for n in range(min_num, max_num + 1) for i in range(1, n + 1) for j in range(1, n + 1) if
+        i * j <= max_num and i * j >= min_num)
+    target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
+
+    # find the closest aspect ratio to the target
+    target_aspect_ratio = find_closest_aspect_ratio(
+        aspect_ratio, target_ratios, orig_width, orig_height, image_size)
+
+    # calculate the target width and height
+    target_width = image_size * target_aspect_ratio[0]
+    target_height = image_size * target_aspect_ratio[1]
+    blocks = target_aspect_ratio[0] * target_aspect_ratio[1]
+
+    # resize the image
+    resized_img = image.resize((target_width, target_height))
+    processed_images = []
+    for i in range(blocks):
+        box = (
+            (i % (target_width // image_size)) * image_size,
+            (i // (target_width // image_size)) * image_size,
+            ((i % (target_width // image_size)) + 1) * image_size,
+            ((i // (target_width // image_size)) + 1) * image_size
+        )
+        # split the image
+        split_img = resized_img.crop(box)
+        processed_images.append(split_img)
+    assert len(processed_images) == blocks
+    if use_thumbnail and len(processed_images) != 1:
+        thumbnail_img = image.resize((image_size, image_size))
+        processed_images.append(thumbnail_img)
+    return processed_images
+
+
+def load_image(image_file, input_size=448, max_num=12):
+    image = Image.open(image_file).convert('RGB')
+    transform = build_transform(input_size=input_size)
+    images = dynamic_preprocess(image, image_size=input_size, use_thumbnail=True, max_num=max_num)
+    pixel_values = [transform(image) for image in images]
+    pixel_values = torch.stack(pixel_values)
+    return pixel_values
+
+
+def get_index(bound, fps, max_frame, first_idx=0, num_segments=32):
+    if bound:
+        start, end = bound[0], bound[1]
+    else:
+        start, end = -100000, 100000
+    start_idx = max(first_idx, round(start * fps))
+    end_idx = min(round(end * fps), max_frame)
+    seg_size = float(end_idx - start_idx) / num_segments
+    frame_indices = np.array([
+        int(start_idx + (seg_size / 2) + np.round(seg_size * idx))
+        for idx in range(num_segments)
+    ])
+    return frame_indices
+
+
+def load_video(video_path, bound=None, input_size=448, max_num=1, num_segments=32):
+    vr = VideoReader(video_path, ctx=cpu(0), num_threads=1)
+    max_frame = len(vr) - 1
+    fps = float(vr.get_avg_fps())
+
+    pixel_values_list, num_patches_list = [], []
+    transform = build_transform(input_size=input_size)
+    frame_indices = get_index(bound, fps, max_frame, first_idx=0, num_segments=num_segments)
+    for frame_index in frame_indices:
+        img = Image.fromarray(vr[frame_index].asnumpy()).convert('RGB')
+        img = dynamic_preprocess(img, image_size=input_size, use_thumbnail=True, max_num=max_num)
+        pixel_values = [transform(tile) for tile in img]
+        pixel_values = torch.stack(pixel_values)
+        num_patches_list.append(pixel_values.shape[0])
+        pixel_values_list.append(pixel_values)
+    pixel_values = torch.cat(pixel_values_list)
+    return pixel_values, num_patches_list
+
+
+class SeparatorStyle(IntEnum):
+    """Separator styles."""
+
+    ADD_COLON_SINGLE = auto()
+    ADD_COLON_TWO = auto()
+    ADD_COLON_SPACE_SINGLE = auto()
+    NO_COLON_SINGLE = auto()
+    NO_COLON_TWO = auto()
+    ADD_NEW_LINE_SINGLE = auto()
+    LLAMA2 = auto()
+    CHATGLM = auto()
+    CHATML = auto()
+    CHATINTERN = auto()
+    DOLLY = auto()
+    RWKV = auto()
+    PHOENIX = auto()
+    ROBIN = auto()
+    FALCON_CHAT = auto()
+    CHATGLM3 = auto()
+    INTERNVL_ZH = auto()
+    MPT = auto()
+
+
+@dataclasses.dataclass
+class Conversation:
+    """A class that manages prompt templates and keeps all conversation history."""
+
+    # The name of this template
+    name: str
+    # The template of the system prompt
+    system_template: str = '{system_message}'
+    # The system message
+    system_message: str = ''
+    # The names of two roles
+    roles: Tuple[str] = ('USER', 'ASSISTANT')
+    # All messages. Each item is (role, message).
+    messages: List[List[str]] = ()
+    # The number of few shot examples
+    offset: int = 0
+    # The separator style and configurations
+    sep_style: SeparatorStyle = SeparatorStyle.ADD_COLON_SINGLE
+    sep: str = '\n'
+    sep2: str = None
+    # Stop criteria (the default one is EOS token)
+    stop_str: Union[str, List[str]] = None
+    # Stops generation if meeting any token in this list
+    stop_token_ids: List[int] = None
+
+    def get_prompt(self) -> str:
+        """Get the prompt for generation."""
+        system_prompt = self.system_template.format(system_message=self.system_message)
+        if self.sep_style == SeparatorStyle.ADD_COLON_SINGLE:
+            ret = system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + ': ' + message + self.sep
+                else:
+                    ret += role + ':'
+            return ret
+        elif self.sep_style == SeparatorStyle.ADD_COLON_TWO:
+            seps = [self.sep, self.sep2]
+            ret = system_prompt + seps[0]
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += role + ': ' + message + seps[i % 2]
+                else:
+                    ret += role + ':'
+            return ret
+        elif self.sep_style == SeparatorStyle.ADD_COLON_SPACE_SINGLE:
+            ret = system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + ': ' + message + self.sep
+                else:
+                    ret += role + ': '  # must be end with a space
+            return ret
+        elif self.sep_style == SeparatorStyle.ADD_NEW_LINE_SINGLE:
+            ret = '' if system_prompt == '' else system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + '\n' + message + self.sep
+                else:
+                    ret += role + '\n'
+            return ret
+        elif self.sep_style == SeparatorStyle.NO_COLON_SINGLE:
+            ret = system_prompt
+            for role, message in self.messages:
+                if message:
+                    ret += role + message + self.sep
+                else:
+                    ret += role
+            return ret
+        elif self.sep_style == SeparatorStyle.NO_COLON_TWO:
+            seps = [self.sep, self.sep2]
+            ret = system_prompt
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += role + message + seps[i % 2]
+                else:
+                    ret += role
+            return ret
+        elif self.sep_style == SeparatorStyle.RWKV:
+            ret = system_prompt
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += (
+                        role
+                        + ': '
+                        + message.replace('\r\n', '\n').replace('\n\n', '\n')
+                    )
+                    ret += '\n\n'
+                else:
+                    ret += role + ':'
+            return ret
+        elif self.sep_style == SeparatorStyle.LLAMA2:
+            seps = [self.sep, self.sep2]
+            if self.system_message:
+                ret = system_prompt
+            else:
+                ret = '[INST] '
+            for i, (role, message) in enumerate(self.messages):
+                tag = self.roles[i % 2]
+                if message:
+                    if i == 0:
+                        ret += message + ' '
+                    else:
+                        ret += tag + ' ' + message + seps[i % 2]
+                else:
+                    ret += tag
+            return ret
+        elif self.sep_style == SeparatorStyle.CHATGLM:
+            # source: https://huggingface.co/THUDM/chatglm-6b/blob/1d240ba371910e9282298d4592532d7f0f3e9f3e/modeling_chatglm.py#L1302-L1308
+            # source2: https://huggingface.co/THUDM/chatglm2-6b/blob/e186c891cf64310ac66ef10a87e6635fa6c2a579/modeling_chatglm.py#L926
+            round_add_n = 1 if self.name == 'chatglm2' else 0
+            if system_prompt:
+                ret = system_prompt + self.sep
+            else:
+                ret = ''
+
+            for i, (role, message) in enumerate(self.messages):
+                if i % 2 == 0:
+                    ret += f'[Round {i//2 + round_add_n}]{self.sep}'
+
+                if message:
+                    ret += f'{role}：{message}{self.sep}'
+                else:
+                    ret += f'{role}：'
+            return ret
+        elif self.sep_style == SeparatorStyle.CHATML:
+            ret = '' if system_prompt == '' else system_prompt + self.sep + '\n'
+            for role, message in self.messages:
+                if message:
+                    ret += role + '\n' + message + self.sep + '\n'
+                else:
+                    ret += role + '\n'
+            return ret
+        elif self.sep_style == SeparatorStyle.CHATGLM3:
+            ret = ''
+            if self.system_message:
+                ret += system_prompt
+            for role, message in self.messages:
+                if message:
+                    ret += role + '\n' + ' ' + message
+                else:
+                    ret += role
+            return ret
+        elif self.sep_style == SeparatorStyle.CHATINTERN:
+            # source: https://huggingface.co/internlm/internlm-chat-7b-8k/blob/bd546fa984b4b0b86958f56bf37f94aa75ab8831/modeling_internlm.py#L771
+            seps = [self.sep, self.sep2]
+            ret = system_prompt
+            for i, (role, message) in enumerate(self.messages):
+                # if i % 2 == 0:
+                #     ret += "<s>"
+                if message:
+                    ret += role + ':' + message + seps[i % 2] + '\n'
+                else:
+                    ret += role + ':'
+            return ret
+        elif self.sep_style == SeparatorStyle.DOLLY:
+            seps = [self.sep, self.sep2]
+            ret = system_prompt
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += role + ':\n' + message + seps[i % 2]
+                    if i % 2 == 1:
+                        ret += '\n\n'
+                else:
+                    ret += role + ':\n'
+            return ret
+        elif self.sep_style == SeparatorStyle.PHOENIX:
+            ret = system_prompt
+            for role, message in self.messages:
+                if message:
+                    ret += role + ': ' + '<s>' + message + '</s>'
+                else:
+                    ret += role + ': ' + '<s>'
+            return ret
+        elif self.sep_style == SeparatorStyle.ROBIN:
+            ret = system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + ':\n' + message + self.sep
+                else:
+                    ret += role + ':\n'
+            return ret
+        elif self.sep_style == SeparatorStyle.FALCON_CHAT:
+            ret = ''
+            if self.system_message:
+                ret += system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + ': ' + message + self.sep
+                else:
+                    ret += role + ':'
+
+            return ret
+        elif self.sep_style == SeparatorStyle.INTERNVL_ZH:
+            seps = [self.sep, self.sep2]
+            ret = self.system_message + seps[0]
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += role + ': ' + message + seps[i % 2]
+                else:
+                    ret += role + ':'
+            return ret
+        elif self.sep_style == SeparatorStyle.MPT:
+            ret = system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    if type(message) is tuple:
+                        message, _, _ = message
+                    ret += role + message + self.sep
+                else:
+                    ret += role
+            return ret
+        else:
+            raise ValueError(f'Invalid style: {self.sep_style}')
+
+    def set_system_message(self, system_message: str):
+        """Set the system message."""
+        self.system_message = system_message
+
+    def append_message(self, role: str, message: str):
+        """Append a new message."""
+        self.messages.append([role, message])
+
+    def update_last_message(self, message: str):
+        """Update the last output.
+
+        The last message is typically set to be None when constructing the prompt,
+        so we need to update it in-place after getting the response from a model.
+        """
+        self.messages[-1][1] = message
+
+    def to_gradio_chatbot(self):
+        """Convert the conversation to gradio chatbot format."""
+        ret = []
+        for i, (role, msg) in enumerate(self.messages[self.offset :]):
+            if i % 2 == 0:
+                ret.append([msg, None])
+            else:
+                ret[-1][-1] = msg
+        return ret
+
+    def to_openai_api_messages(self):
+        """Convert the conversation to OpenAI chat completion format."""
+        ret = [{'role': 'system', 'content': self.system_message}]
+
+        for i, (_, msg) in enumerate(self.messages[self.offset :]):
+            if i % 2 == 0:
+                ret.append({'role': 'user', 'content': msg})
+            else:
+                if msg is not None:
+                    ret.append({'role': 'assistant', 'content': msg})
+        return ret
+
+    def copy(self):
+        return Conversation(
+            name=self.name,
+            system_template=self.system_template,
+            system_message=self.system_message,
+            roles=self.roles,
+            messages=[[x, y] for x, y in self.messages],
+            offset=self.offset,
+            sep_style=self.sep_style,
+            sep=self.sep,
+            sep2=self.sep2,
+            stop_str=self.stop_str,
+            stop_token_ids=self.stop_token_ids,
+        )
+
+    def dict(self):
+        return {
+            'template_name': self.name,
+            'system_message': self.system_message,
+            'roles': self.roles,
+            'messages': self.messages,
+            'offset': self.offset,
+        }
+
+
+# A global registry for all conversation templates
+conv_templates: Dict[str, Conversation] = {}
+
+
+def register_conv_template(template: Conversation, override: bool = False):
+    """Register a new conversation template."""
+    if not override:
+        assert (
+            template.name not in conv_templates
+        ), f'{template.name} has been registered.'
+
+    conv_templates[template.name] = template
+
+
+def get_conv_template(name: str) -> Conversation:
+    """Get a conversation template."""
+    return conv_templates[name].copy()
+
+
+# Both Hermes-2 and internlm2-chat are chatml-format conversation templates. The difference
+# is that during training, the preprocessing function for the Hermes-2 template doesn't add
+# <s> at the beginning of the tokenized sequence, while the internlm2-chat template does.
+# Therefore, they are completely equivalent during inference.
+register_conv_template(
+    Conversation(
+        name='Hermes-2',
+        system_template='<|im_start|>system\n{system_message}',
+        # note: The new system prompt was not used here to avoid changes in benchmark performance.
+        # system_message='我是书生·万象，英文名是InternVL，是由上海人工智能实验室、清华大学及多家合作单位联合开发的多模态大语言模型。',
+        system_message='你是由上海人工智能实验室联合商汤科技开发的书生多模态大模型，英文名叫InternVL, 是一个有用无害的人工智能助手。',
+        roles=('<|im_start|>user\n', '<|im_start|>assistant\n'),
+        sep_style=SeparatorStyle.MPT,
+        sep='<|im_end|>',
+        stop_str='<|endoftext|>',
+    )
+)
+
+
+register_conv_template(
+    Conversation(
+        name='internlm2-chat',
+        system_template='<|im_start|>system\n{system_message}',
+        # note: The new system prompt was not used here to avoid changes in benchmark performance.
+        # system_message='我是书生·万象，英文名是InternVL，是由上海人工智能实验室、清华大学及多家合作单位联合开发的多模态大语言模型。',
+        system_message='你是由上海人工智能实验室联合商汤科技开发的书生多模态大模型，英文名叫InternVL, 是一个有用无害的人工智能助手。',
+        roles=('<|im_start|>user\n', '<|im_start|>assistant\n'),
+        sep_style=SeparatorStyle.MPT,
+        sep='<|im_end|>',
+    )
+)
+
+
+register_conv_template(
+    Conversation(
+        name='phi3-chat',
+        system_template='<|system|>\n{system_message}',
+        # note: The new system prompt was not used here to avoid changes in benchmark performance.
+        # system_message='我是书生·万象，英文名是InternVL，是由上海人工智能实验室、清华大学及多家合作单位联合开发的多模态大语言模型。',
+        system_message='你是由上海人工智能实验室联合商汤科技开发的书生多模态大模型，英文名叫InternVL, 是一个有用无害的人工智能助手。',
+        roles=('<|user|>\n', '<|assistant|>\n'),
+        sep_style=SeparatorStyle.MPT,
+        sep='<|end|>',
+    )
+)
+
+
+register_conv_template(
+    Conversation(
+        name='internvl2_5',
+        system_template='<|im_start|>system\n{system_message}',
+        system_message='你是书生·万象，英文名是InternVL，是由上海人工智能实验室、清华大学及多家合作单位联合开发的多模态大语言模型。',
+        roles=('<|im_start|>user\n', '<|im_start|>assistant\n'),
+        sep_style=SeparatorStyle.MPT,
+        sep='<|im_end|>\n',
+    )
+)
+
+
+@register_collator("internvl2")
+class InternVL2DataCollator(BaseDataCollator):
+    def __call__(self, instances: Sequence[Dict]) -> Dict[str, torch.Tensor]:
+        # images
+        # for internvl2 these are filepaths to the images
+        image_paths: List[List] = [instance["images"] for instance in instances]
+        pixel_values = []
+
+        # texts
+        # the dataset implementation assume conversations are [user, assistant, user, assistant, ...]
+        system_prompts: List[Union[str, None]] = [instance["system_prompt"] for instance in instances]
+        conversations: List[List] = [instance["conversations"] for instance in instances]
+        input_ids = []
+        labels = []
+
+        # constants
+        max_len = self.tokenizer.model_max_length
+        image_size = self.config.force_image_size or config.vision_config.image_size
+        patch_size = self.config.vision_config.patch_size
+        num_image_token = int((image_size // patch_size) ** 2 * (self.config.downsample_ratio ** 2))
+
+        for cur_image_paths, system_prompt, cur_convs in zip(image_paths, system_prompts, conversations):
+            cur_num_images = len(cur_image_paths)
+            cur_input_ids = []
+            cur_labels = []
+
+            cur_pixel_values = []
+            cur_num_patches_list = []
+            for cur_image_path in cur_image_paths:
+                pixel_value = load_image(cur_image_path, max_num=12)
+                cur_pixel_values.append(pixel_value)
+                cur_num_patches_list.append(pixel_value.shape[0])
+            cur_pixel_values = torch.cat(cur_pixel_values, dim=0)
+
+            template = get_conv_template(self.config.template)
+            if system_prompt is not None:
+                template.system_message = system_prompt
+
+            for i, text in enumerate(cur_convs):
+                if i % 2 == 0:
+                    template.append_message(template.roles[0], text)
+                else:
+                    template.append_message(template.roles[1], text)
+
+            prompt = template.get_prompt()
+            for num_patches in cur_num_patches_list:
+                image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * num_image_token * num_patches + IMG_END_TOKEN
+                prompt = prompt.replace("<image>", image_tokens, 1)
+
+            cur_input_ids = self.tokenizer(
+                prompt,
+                return_tensors="pt",
+                padding="max_length",
+                max_length=max_len,
+                truncation=True,
+            ).input_ids
+            cur_labels = cur_input_ids.clone()
+
+            # TODO: question mask
+
+            pixel_values.append(cur_pixel_values)
+            input_ids.append(cur_input_ids)
+            labels.append(cur_labels)
+
+        pixel_values = torch.cat(pixel_values)
+        input_ids = torch.cat(input_ids)
+        labels = torch.cat(labels)
+
+        return dict(
+            pixel_values=pixel_values,
+            input_ids=input_ids,
+            labels=labels,
+            attention_mask=input_ids.ne(self.PAD_TOKEN_ID),
+        )

--- a/collators/internvl2.py
+++ b/collators/internvl2.py
@@ -1,5 +1,4 @@
 import dataclasses
-import re
 from enum import IntEnum, auto
 from typing import Dict, List, Sequence, Tuple, Union
 
@@ -11,7 +10,6 @@ from torchvision.transforms.functional import InterpolationMode
 
 from . import register_collator
 from .base import BaseDataCollator
-from .chat_template_monkey_patch import apply_chat_template
 
 
 IMG_START_TOKEN = '<img>'
@@ -567,7 +565,32 @@ class InternVL2DataCollator(BaseDataCollator):
             ).input_ids
             cur_labels = cur_input_ids.clone()
 
-            # TODO: question mask
+            # TODO: mask question tokens
+            assert self.mask_question_tokens, "self.mask_question_tokens should be True"
+
+            total_len = int(cur_labels.ne(self.PAD_TOKEN_ID).sum())
+            cur_len = 1
+            cur_labels[:, :cur_len] = self.IGNORE_TOKEN_ID
+            parts = prompt.split(template.roles[1])
+            info = parts[0] + template.roles[1]
+            temp_len = len(self.tokenizer(info).input_ids) - 1
+            cur_labels[:, cur_len: cur_len + temp_len] = self.IGNORE_TOKEN_ID
+            cur_len = cur_len + temp_len
+
+            for index in range(1, len(parts) - 1):
+                info = parts[index]
+                part1, part2 = info.split(template.roles[0])
+                temp_len = len(self.tokenizer(part1).input_ids) - 1
+                cur_len = cur_len + temp_len
+                part = template.roles[0] + part2 + template.roles[1]
+                temp_len = len(self.tokenizer(part).input_ids) - 1
+                cur_labels[:, cur_len: cur_len + temp_len] = self.IGNORE_TOKEN_ID
+                cur_len = cur_len + temp_len
+            last_info = parts[-1]
+            temp_len = len(self.tokenizer(last_info).input_ids) - 1
+            cur_len = cur_len + temp_len
+
+            cur_labels[:, cur_len:] = self.IGNORE_TOKEN_ID
 
             pixel_values.append(cur_pixel_values)
             input_ids.append(cur_input_ids)

--- a/collators/internvl2.py
+++ b/collators/internvl2.py
@@ -585,4 +585,5 @@ class InternVL2DataCollator(BaseDataCollator):
             input_ids=input_ids,
             labels=labels,
             attention_mask=input_ids.ne(self.PAD_TOKEN_ID),
+            image_flags=torch.tensor([1] * pixel_values.size(0), dtype=torch.long),
         )

--- a/datasets.py
+++ b/datasets.py
@@ -19,6 +19,7 @@ TO_LOAD_IMAGE: Dict[str, bool] = {
     "qwen2-vl": True,
     "qwen2.5-vl": True,
     "llama-3.2-vision": True,
+    "internvl2": False,
 }
 
 

--- a/loaders/__init__.py
+++ b/loaders/__init__.py
@@ -19,3 +19,4 @@ from .phi3_v import Phi3VModelLoader
 from .qwen2_vl import Qwen2VLModelLoader
 from .qwen2_5_vl import Qwen2_5_VLModelLoader
 from .llama_3_2_vision import LLaMA3_2_VisionModelLoader
+from .internvl2 import InternVL2ModelLoader

--- a/loaders/internvl2.py
+++ b/loaders/internvl2.py
@@ -6,6 +6,9 @@ from . import register_loader
 from .base import BaseModelLoader
 
 
+IMG_CONTEXT_TOKEN = '<IMG_CONTEXT>'
+
+
 @register_loader("internvl2")
 class InternVL2ModelLoader(BaseModelLoader):
     def load(self, load_model: bool = True) -> Tuple[AutoModel, PreTrainedTokenizer, AutoProcessor, AutoConfig]:
@@ -22,6 +25,10 @@ class InternVL2ModelLoader(BaseModelLoader):
         processor = AutoProcessor.from_pretrained(self.model_hf_path, trust_remote_code=True)
         tokenizer = AutoTokenizer.from_pretrained(self.model_hf_path, trust_remote_code=True)
         config = AutoConfig.from_pretrained(self.model_local_path, trust_remote_code=True)
+
+        img_context_token_id = tokenizer.convert_tokens_to_ids(IMG_CONTEXT_TOKEN)
+        model.img_context_token_id = img_context_token_id
+
         return model, tokenizer, processor, config
 
 

--- a/loaders/internvl2.py
+++ b/loaders/internvl2.py
@@ -1,0 +1,35 @@
+from typing import Tuple
+
+from transformers import AutoProcessor, AutoModel, AutoTokenizer, PreTrainedTokenizer, AutoConfig
+
+from . import register_loader
+from .base import BaseModelLoader
+
+
+@register_loader("internvl2")
+class InternVL2ModelLoader(BaseModelLoader):
+    def load(self, load_model: bool = True) -> Tuple[AutoModel, PreTrainedTokenizer, AutoProcessor, AutoConfig]:
+        if load_model:
+            model = AutoModel.from_pretrained(
+                self.model_local_path,
+                trust_remote_code=True,
+                **self.loading_kwargs,
+            )
+            model.config.hidden_size = model.config.llm_config.hidden_size # useful for deepspeed
+        else:
+            model = None
+
+        processor = AutoProcessor.from_pretrained(self.model_hf_path, trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_hf_path, trust_remote_code=True)
+        config = AutoConfig.from_pretrained(self.model_local_path, trust_remote_code=True)
+        return model, tokenizer, processor, config
+
+
+if __name__ == "__main__":
+    import torch
+    loader = InternVL2ModelLoader(
+        model_hf_path="OpenGVLab/InternVL2-8B",
+        model_local_path="/aiarena/group/gmgroup/hongyq/models/OpenGVLab/InternVL2-8B",
+        compute_dtype=torch.bfloat16,
+    )
+    model, tokenizer, processor, config = loader.load()

--- a/supported_models.py
+++ b/supported_models.py
@@ -226,6 +226,12 @@ register_model(
 
 # internvl2 --------------------------------------------------
 register_model(
+    model_id="internvl2-2b",
+    model_family_id="internvl2",
+    model_hf_path="OpenGVLab/InternVL2-2B"
+)
+
+register_model(
     model_id="internvl2-8b",
     model_family_id="internvl2",
     model_hf_path="OpenGVLab/InternVL2-8B"

--- a/supported_models.py
+++ b/supported_models.py
@@ -60,6 +60,11 @@ MODULE_KEYWORDS: Dict[str, Dict[str, List]] = {
         "vision_encoder": ["vision_model"],
         "vision_projector": ["multi_modal_projector"],
         "llm": ["language_model"]
+    },
+    "internvl2": {
+        "vision_encoder": ["vision_model"],
+        "vision_projector": ["mlp1"],
+        "llm": ["language_model"]
     }
 }
 
@@ -207,7 +212,6 @@ register_model(
 )
 
 # llama-3.2-vision -------------------------------------------
-
 register_model(
     model_id="llama-3.2-11b-vision-instruct",
     model_family_id="llama-3.2-vision",
@@ -218,6 +222,13 @@ register_model(
     model_id="llama-3.2-90b-vision-instruct",
     model_family_id="llama-3.2-vision",
     model_hf_path="meta-llama/Llama-3.2-90B-Vision-Instruct"
+)
+
+# internvl2 --------------------------------------------------
+register_model(
+    model_id="internvl2-8b",
+    model_family_id="internvl2",
+    model_hf_path="OpenGVLab/InternVL2-8B"
 )
 
 #=============================================================


### PR DESCRIPTION
This PR heavily borrows code from [https://github.com/OpenGVLab/InternVL](https://github.com/OpenGVLab/InternVL) and [https://huggingface.co/OpenGVLab/InternVL2-8B](https://huggingface.co/OpenGVLab/InternVL2-8B).  
I *loathe* this model for not having `apply_chat_template`.

Currently, only the 2B and 8B models are supported for training, because the other models use different language-model backbones, which makes them a bit more troublesome to handle.

Before starting training, please download the model locally and modify `modeling_internvl_chat.py` by adding `**kwargs` to the input arguments of the `forward` function in `InternVLChatModel`.
